### PR TITLE
Fix Compiler error in InterpolatedLookupTable::add function

### DIFF
--- a/Source/CarbonEngine/Math/InterpolatedLookupTable.h
+++ b/Source/CarbonEngine/Math/InterpolatedLookupTable.h
@@ -34,7 +34,7 @@ public:
      */
     void add(const IndexType& index, const ValueType& value)
     {
-        auto entryIndex = entries_.binarySearch(LookupEntry(index));
+        auto entryIndex = entries_.binarySearch(LookupEntry(index, value));
 
         if (entryIndex >= 0)
             entries_[entryIndex].second = value;


### PR DESCRIPTION
Added missing parameter required to create std::pair in add function